### PR TITLE
walleye\taimen: Move to gapps build (23/06/23 Update)

### DIFF
--- a/gapps/taimen.json
+++ b/gapps/taimen.json
@@ -1,0 +1,20 @@
+{
+  "error": false,
+  "version": "13",
+  "url": "https://sourceforge.net/projects/bananadroid/files/taimen/BananaDroid-Tanduk-taimen-OFFICIAL-20230623-GApps.zip",
+  "github_releases_url": "https://sourceforge.net/projects/bananadroid/files/taimen/BananaDroid-Tanduk-taimen-OFFICIAL-20230623-GApps.zip",
+  "datetime": 1687514194,
+  "filehash": "0776687f3c52cf003af5d25e8144df8f",
+  "filename": "BananaDroid-Tanduk-taimen-OFFICIAL-20230623-GApps.zip",
+  "id": "8b44c5754dd94a45fdcf2cb584ddb91eaced0d9d9e2689869b40fc86c59d6b06",
+  "size": 1506462464,
+  "maintainers": [
+    {
+      "github_username": "@asriadirahim",
+      "name": "@asriadirahim"
+    }
+  ],
+  "donate_url": "https://paypal.me/travarilo",
+  "website_url": "https://bananadroid.com",
+  "forum_url": "https://t.me/bananadroid"
+}

--- a/gapps/taimen.md
+++ b/gapps/taimen.md
@@ -1,0 +1,15 @@
+====================
+    06-23-2023  
+====================
+
+Changeslog:
+- May security patch
+- Gapps build
+- Enable AOSP surfaceflinger
+- Switch to AutoSingleLayer Android 13 Setting
+- Enable ro.hwui.render_ahead
+- Lower gps debug level
+- Disable battery health
+
+Notes:
+- Clean flash required from vanilla build

--- a/gapps/walleye.json
+++ b/gapps/walleye.json
@@ -1,0 +1,20 @@
+{
+  "error": false,
+  "version": "13",
+  "url": "https://sourceforge.net/projects/bananadroid/files/walleye/BananaDroid-Tanduk-walleye-OFFICIAL-20230623-GApps.zip",
+  "github_releases_url": "https://sourceforge.net/projects/bananadroid/files/walleye/BananaDroid-Tanduk-walleye-OFFICIAL-20230623-GApps.zip",
+  "datetime": 1687531461,
+  "filehash": "9b1d89a389b50e1911e56892953cb853",
+  "filename": "BananaDroid-Tanduk-walleye-OFFICIAL-20230623-GApps.zip",
+  "id": "d762316d39a4f40ffb52cc84e82c4ff60565559bd83f72fa514569962989702f",
+  "size": 1465758792,
+  "maintainers": [
+    {
+      "github_username": "@asriadirahim",
+      "name": "@asriadirahim"
+    }
+  ],
+  "donate_url": "https://paypal.me/travarilo",
+  "website_url": "https://bananadroid.com",
+  "forum_url": "https://t.me/bananadroid"
+}

--- a/gapps/walleye.md
+++ b/gapps/walleye.md
@@ -1,0 +1,15 @@
+====================
+    06-23-2023  
+====================
+
+Changeslog:
+- May security patch
+- Gapps build
+- Enable AOSP surfaceflinger
+- Switch to AutoSingleLayer Android 13 Setting
+- Enable ro.hwui.render_ahead
+- Lower gps debug level
+- Disable battery health
+
+Notes:
+- Clean flash required from vanilla build


### PR DESCRIPTION
* [TMP]: Drop vanilla build for both